### PR TITLE
#1: Redirect after destroy unique roster to original location

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,3 +30,7 @@ Fixes [#XXX]()
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
+
+# Notes / Details
+
+<!--- If any other details or notes, whether more indepth of your PR or details you added related or not go here --->

--- a/app/controllers/rosters_controller.rb
+++ b/app/controllers/rosters_controller.rb
@@ -32,6 +32,8 @@ class RostersController < ApplicationController
 
   def show
     @roster = roster
+    @team_id = team.id
+    @lesson_id = lesson.id
   end
 
   def destroy

--- a/app/controllers/unique_rosters_controller.rb
+++ b/app/controllers/unique_rosters_controller.rb
@@ -38,6 +38,7 @@ class UniqueRostersController < ApplicationController
     if params[:student].present?
       redirect_to team_student_path(params[:team], params[:student])
     elsif params[:lesson].present?
+      redirect_to team_lesson_roster_path(params[:team], params[:lesson], params[:roster])
     end
   end
 

--- a/app/controllers/unique_rosters_controller.rb
+++ b/app/controllers/unique_rosters_controller.rb
@@ -18,21 +18,27 @@ class UniqueRostersController < ApplicationController
 
   def destroy
     @unique_roster = unique_roster
-    binding.pry
 
     if @unique_roster.destroy
-      flash[:alert] = "Deleted"
+      flash[:alert] = "Student removed from class."
     else
       flash[:alert] = "#{model_error_string(@lesson)}"
     end
 
-    redirect_to root_path
+    redirect(params)
   end
 
   private
 
   def lesson
     Lesson.find(unique_roster_params[:lesson_id])
+  end
+
+  def redirect(params)
+    if params[:student].present?
+      redirect_to team_student_path(params[:team], params[:student])
+    elsif params[:lesson].present?
+    end
   end
 
   def roster

--- a/app/controllers/unique_rosters_controller.rb
+++ b/app/controllers/unique_rosters_controller.rb
@@ -5,7 +5,6 @@ class UniqueRostersController < ApplicationController
   before_action :authenticate_user!
 
   def create
-
     @unique_roster = student.unique_rosters.build(unique_roster_params)
 
     if @unique_roster.save
@@ -19,6 +18,7 @@ class UniqueRostersController < ApplicationController
 
   def destroy
     @unique_roster = unique_roster
+    binding.pry
 
     if @unique_roster.destroy
       flash[:alert] = "Deleted"

--- a/app/views/rosters/show.html.erb
+++ b/app/views/rosters/show.html.erb
@@ -38,7 +38,7 @@
             </div>
           </div>
           <div>
-            <%= button_to "X", unique_roster_path(ur.id), data: { confirm: 'Are you sure you want to delete this student?', test: "delete-student-from-ur-#{ur.id}" }, method: :delete, class: "delete-btn" %>
+            <%= button_to "X", unique_roster_path(id: ur.id, team: @team_id, lesson: @lesson_id, roster: @roster.id), data: { confirm: 'Are you sure you want to delete this student?', test: "delete-student-from-ur-#{ur.id}" }, method: :delete, class: "delete-btn" %>
           </div>
         </li>
       <% end %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -55,7 +55,7 @@
             </div>
 
             <div>
-              <%= button_to "X", unique_roster_path(ur.id), data: { confirm: 'Are you sure you want to delete this student?', test: "delete-ur-#{ur.id}" }, method: :delete, class: "delete-btn" %>
+              <%= button_to "X", unique_roster_path(id: ur.id, team: @student.team_id, student: @student.id), data: { confirm: 'Are you sure you want to delete this student?', test: "delete-ur-#{ur.id}" }, method: :delete, class: "delete-btn" %>
             </div>
           </li>
         <% end %>

--- a/spec/factories/unique_rosters.rb
+++ b/spec/factories/unique_rosters.rb
@@ -3,9 +3,5 @@ FactoryBot.define do
     association :student
     association :roster
     association :lesson
-
-    student { nil }
-    roster { nil }
-    lesson { nil }
   end
 end

--- a/spec/features/unique_roster_management/redirect_after_delete_unique_roster.rb
+++ b/spec/features/unique_roster_management/redirect_after_delete_unique_roster.rb
@@ -44,6 +44,18 @@ RSpec.feature 'redirection after deleting unique roster' do
 
     context 'delete from roster profile' do
       scenario 'redirects to roster profile' do
+        unique_roster = create(:unique_roster, student_id: @student.id, lesson_id: @lesson.id, roster_id: @roster.id)
+
+        visit team_lesson_roster_path(@team.id, @lesson.id, @roster.id)
+
+        expect(page.body).to have_content(@roster.name)
+        expect(page.body).to have_content(@student.contact)
+
+        find("[data-test=\"delete-student-from-ur-#{unique_roster.id}\"]").click
+
+        expect(page.body).to have_content("Student removed from class.")
+        expect(page.body).to have_content(@roster.name)
+        expect(page.body).to_not have_content(@student.contact)
       end
     end
   end

--- a/spec/features/unique_roster_management/redirect_after_delete_unique_roster.rb
+++ b/spec/features/unique_roster_management/redirect_after_delete_unique_roster.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.feature 'redirection after deleting unique roster' do
+  let!(:user) { create :user }
+  let!(:team) { create :team }
+  let!(:lesson) { create :lesson }
+  let!(:student) { create :student }
+  let!(:roster) { create :roster }
+
+  describe 'success' do
+    before(:each) do
+      @team = create(:team)
+      @lesson = create(:lesson)
+      @student = create(:student)
+      @roster = create(:roster)
+
+      user.teams << @team
+      @team.lessons << @lesson
+      @lesson.rosters << @roster
+      @team.students << @student
+      sign_in user
+    end
+
+    context 'delete from student profile' do
+      scenario 'redirects to student profile' do
+        visit team_student_path(@team.id, @student.id)
+
+        find('#unique_roster_lesson_id').find(:xpath, 'option[2]').select_option
+        find('#unique_roster_roster_id').find(:xpath, 'option[2]').select_option
+        find('[data-test="add-unique-roster"]').click
+
+        expect(page.body).to have_content("Student added to Roster!")
+        expect(@student.unique_rosters).not_to be_empty
+
+        @unique_roster = @student.unique_rosters.first
+
+        find("[data-test=\"delete-ur-#{@unique_roster.id}\"]").click
+
+        expect(page.body).to have_content("Student removed from class.")
+        expect(page.body).to have_content(@student.name)
+        expect(page.body).to have_content(@student.contact)
+      end
+    end
+
+    context 'delete from roster profile' do
+      scenario 'redirects to roster profile' do
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. --->
When deleting a unique roster, redirect back to the page that the unique roster was deleted.

<!-- Link to Trello card if applicable -->

Fixes [#1](https://trello.com/c/lZXquCjh)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --->

- [x] Rspec test: `redirect_after_delete_unique_roster`

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules